### PR TITLE
Fix building on MacOS + arm64

### DIFF
--- a/BuilderCompile.js
+++ b/BuilderCompile.js
@@ -108,7 +108,12 @@ class BuilderCompile {
             }
             // for an off-chance that your %LOCALAPPDATA%/GameMakerStudio2 directory doesn't exist
             if (!Electron_FS.existsSync(Temporary)) Electron_FS.mkdirSync(Temporary);
-            Temporary += `${isWindows ? "" : "/GameMakerStudio2"}/GMS2TEMP`;
+            if (!isWindows) {
+                Temporary += "/GameMakerStudio2";
+                if (!Electron_FS.existsSync(Temporary)) Electron_FS.mkdirSync(Temporary);
+            }
+            Temporary += "/GMS2TEMP";
+            if (!Electron_FS.existsSync(Temporary)) Electron_FS.mkdirSync(Temporary);
             if (!Electron_FS.existsSync(Temporary)) Electron_FS.mkdirSync(Temporary);
         }
         output.write("Temp directory: " + Temporary);
@@ -120,7 +125,9 @@ class BuilderCompile {
         // Check for GMAssetCompiler and Runner files!
         let GMAssetCompilerDirOrig = Builder.Runtime + "/bin";
         let GMAssetCompilerPathOrig = GMAssetCompilerDirOrig + "/GMAssetCompiler.exe";
-        let GMAssetCompilerDir2022 = `${Builder.Runtime}/bin/assetcompiler/${isWindows ? "windows" : "osx"}/x64`;
+        const GMAssetCompilerDir2022Container = `${Builder.Runtime}/bin/assetcompiler/${isWindows ? "windows" : "osx"}`;
+        const isArm = Electron_FS.existsSync(`${GMAssetCompilerDir2022Container}/arm64`);
+        let GMAssetCompilerDir2022 = `${Builder.Runtime}/bin/assetcompiler/${isWindows ? "windows" : "osx"}/${isArm ? 'arm64' : 'x86'}`;
         let GMAssetCompilerPath2022 = `${GMAssetCompilerDir2022}/GMAssetCompiler${isWindows ? ".exe" : ""}`;
         let GMAssetCompilerDir = GMAssetCompilerDirOrig;
         let GMAssetCompilerPath = GMAssetCompilerPathOrig;
@@ -153,7 +160,7 @@ class BuilderCompile {
                 x64flag = true;
             } else runnerPath = null;
         } else {
-            if (Electron_FS.existsSync(runnerPath = `${Builder.Runtime}/mac/YoYo Runner.app`)) {
+            if (Electron_FS.existsSync(runnerPath = `${Builder.Runtime}/mac/YoYo Runner.app/Contents/MacOS/Mac_Runner`)) {
                 // OK!
             } else runnerPath = null;
         }


### PR DESCRIPTION
Quick fix that allows for `arm64` dir as an option + checks for existence of temp `/GameMakerStudio2` first, as otherwise calling `mkdirSync` with a missing parent hangs.

MacOS `.app`s are folders and can't be called, so the option was either directly calling the internal executable, or appending `open`, which seems potentially more troublesome(?)

I could have a go cleaning up the code involving this stuff as well, but this was mainly so I could use it on my own system quickly.